### PR TITLE
fix(ui): Fix overflow in `TilesCarousel.scss`

### DIFF
--- a/src/components/TitlesCarousel/TitlesCarousel.scss
+++ b/src/components/TitlesCarousel/TitlesCarousel.scss
@@ -5,7 +5,7 @@
 }
 
 .carousel {
-    overflow: hidden;
+    overflow: scroll;
     scroll-behavior: smooth;
     scrollbar-width: none;
     margin: 0 1em;


### PR DESCRIPTION
I just think it is better to have a scrollbar at the bottom. The site will be more accessible if we keep also the default mechanism of formatting. For example Shift+Scroll. It is way easier than buttons.
Let me know what do you think!